### PR TITLE
Add PyPI publishing workflow and update Makefile for package management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,95 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  quality-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: make venv-install
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run linting
+        run: make lint
+
+      - name: Run tests
+        run: make tests
+
+  build:
+    needs: quality-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract version from release tag
+        run: |
+          # Extract version from tag (v1.2.3 -> 1.2.3)
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "📦 Building version: $VERSION"
+
+      - name: Update version in __init__.py
+        run: |
+          # Update version in __init__.py
+          sed -i 's/__version__ = ".*"/__version__ = "'$VERSION'"/' dataspot/__init__.py
+          echo "✅ Updated __init__.py with version $VERSION"
+          grep "__version__" dataspot/__init__.py
+
+      - name: Install build dependencies
+        run: make pypi-install
+
+      - name: Build package
+        run: make pypi-build
+
+      - name: Check package
+        run: make pypi-check
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,22 @@ install: venv-create
 	source $(VENV_NAME)/bin/activate && \
 	uv pip install -e ".[dev]"
 
+pypi-install:
+	source $(VENV_NAME)/bin/activate && \
+	uv pip install build twine
+
+pypi-build:
+	source $(VENV_NAME)/bin/activate && \
+	python3 -m build
+
+pypi-check:
+	source $(VENV_NAME)/bin/activate && \
+	twine check dist/*
+
+pypi-upload: pypi-build
+	source $(VENV_NAME)/bin/activate && \
+	twine upload dist/*
+
 # Handle unknown targets - Support arguments
 %:
 	@:


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow to automate the publishing process to PyPI upon release.
- Added Makefile targets for installing build dependencies, building the package, checking the package, and uploading to PyPI.
- Enhanced the CI process to include version extraction and updating the package version in `__init__.py` before publishing.