### PR TITLE
Refactor Makefile for simplified PyPI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,19 +49,15 @@ install: venv-create
 	uv pip install -e ".[dev]"
 
 pypi-install:
-	source $(VENV_NAME)/bin/activate && \
-	uv pip install build twine
+	python3 -m pip install --upgrade pip build twine
 
 pypi-build:
-	source $(VENV_NAME)/bin/activate && \
 	python3 -m build
 
 pypi-check:
-	source $(VENV_NAME)/bin/activate && \
 	twine check dist/*
 
 pypi-upload: pypi-build
-	source $(VENV_NAME)/bin/activate && \
 	twine upload dist/*
 
 # Handle unknown targets - Support arguments


### PR DESCRIPTION
- Removed virtual environment activation steps from PyPI-related commands in the Makefile.
- Updated the installation command for build tools to use `python3 -m pip` for better compatibility and consistency.