### PR TITLE
Refactor tree options to use 'limit' instead of 'top' for consistency across analyzers

### DIFF
--- a/dataspot/analyzers/compare.py
+++ b/dataspot/analyzers/compare.py
@@ -340,10 +340,14 @@ class Compare(Base):
             change_threshold=options.change_threshold,
         )
 
+        # Apply limit to changes if specified
+        if options.limit is not None:
+            changes_data = changes_data[: options.limit]
+
         # Convert changes to ChangeItem dataclasses
         changes = [self._dict_to_change_item(change) for change in changes_data]
 
-        # Categorize patterns
+        # Categorize patterns (using limited changes_data)
         categorized_patterns = self._categorize_patterns(changes_data)
 
         # Convert categorized patterns to ChangeItem dataclasses

--- a/dataspot/analyzers/discovery.py
+++ b/dataspot/analyzers/discovery.py
@@ -342,19 +342,23 @@ class Discovery(Base):
             for combo in combinations_tried_data
         ]
 
+        # Apply limit option properly
+        limit = options.limit if options.limit is not None else 20
+        final_patterns = top_patterns[:limit]
+
         # Create DiscoveryStatistics dataclass
         statistics = DiscoveryStatistics(
             total_records=len(data),
             fields_analyzed=len(available_fields),
             combinations_tried=len(combinations_tried),
-            patterns_discovered=len(top_patterns[:20]),
-            best_concentration=max([p.percentage for p in top_patterns[:20]])
-            if top_patterns
+            patterns_discovered=len(final_patterns),
+            best_concentration=max([p.percentage for p in final_patterns])
+            if final_patterns
             else 0,
         )
 
         return DiscoverOutput(
-            top_patterns=top_patterns[:20],  # Top 20 patterns
+            top_patterns=final_patterns,
             field_ranking=field_ranking,
             combinations_tried=combinations_tried,
             statistics=statistics,

--- a/dataspot/analyzers/pattern_extractor.py
+++ b/dataspot/analyzers/pattern_extractor.py
@@ -385,7 +385,7 @@ class TreeBuilder:
         >>>
         >>> print(f"Marketing Dashboard Tree Structure:")
         >>> print(f"- Root value: {tree_structure['value']} total customers")
-        >>> print(f"- top-level channels: {len(tree_structure['children'])}")
+        >>> print(f"- Top-level channels: {len(tree_structure['children'])}")
         >>>
         >>> print(f"\\nChannel Performance Breakdown:")
         >>> for channel in tree_structure['children']:
@@ -397,7 +397,7 @@ class TreeBuilder:
         >>> # Example output:
         >>> # Marketing Dashboard Tree Structure:
         >>> # - Root value: 1000 total customers
-        >>> # - top-level channels: 2
+        >>> # - Top-level channels: 2
         >>> #
         >>> # Channel Performance Breakdown:
         >>> # - email: 50.0% reach

--- a/dataspot/analyzers/pattern_extractor.py
+++ b/dataspot/analyzers/pattern_extractor.py
@@ -352,7 +352,7 @@ class TreeBuilder:
     This class specializes in:
     - Clean tree structure generation for visualization frameworks
     - Hierarchical data organization and optimization
-    - Top-N filtering for focused analysis
+    - top-N filtering for focused analysis
     - JSON-ready format generation with metadata
     - Performance optimization for large pattern sets
     - Statistical measure preservation during transformation
@@ -364,7 +364,7 @@ class TreeBuilder:
     Attributes:
         patterns (List[Pattern]): Source patterns for tree construction.
         total_records (int): Total records for statistical context.
-        top (int): Maximum number of top elements per tree level.
+        limit (int): Maximum number of top elements per tree level.
 
     Example:
         Building visualization trees for business dashboards:
@@ -380,12 +380,12 @@ class TreeBuilder:
         ...     Pattern(path="social > standard", count=200, percentage=20.0, depth=2, samples=[]),
         ... ]
         >>>
-        >>> builder = TreeBuilder(campaign_patterns, total_records=1000, top=5)
+        >>> builder = TreeBuilder(campaign_patterns, total_records=1000, limit=5)
         >>> tree_structure = builder.build()
         >>>
         >>> print(f"Marketing Dashboard Tree Structure:")
         >>> print(f"- Root value: {tree_structure['value']} total customers")
-        >>> print(f"- Top-level channels: {len(tree_structure['children'])}")
+        >>> print(f"- top-level channels: {len(tree_structure['children'])}")
         >>>
         >>> print(f"\\nChannel Performance Breakdown:")
         >>> for channel in tree_structure['children']:
@@ -397,7 +397,7 @@ class TreeBuilder:
         >>> # Example output:
         >>> # Marketing Dashboard Tree Structure:
         >>> # - Root value: 1000 total customers
-        >>> # - Top-level channels: 2
+        >>> # - top-level channels: 2
         >>> #
         >>> # Channel Performance Breakdown:
         >>> # - email: 50.0% reach
@@ -409,13 +409,13 @@ class TreeBuilder:
 
     Notes:
         - Tree structures are optimized for JSON serialization and visualization
-        - Top-N filtering ensures focused analysis on most significant patterns
+        - top-N filtering ensures focused analysis on most significant patterns
         - Hierarchical organization maintains business relationship context
         - Performance is optimized for real-time dashboard and reporting systems
 
     """
 
-    def __init__(self, patterns: List[Pattern], total_records: int, top: int):
+    def __init__(self, patterns: List[Pattern], total_records: int, limit: int):
         """Initialize tree builder with pattern data and configuration.
 
         Sets up the tree building engine with source patterns and optimization
@@ -426,7 +426,7 @@ class TreeBuilder:
                 Each pattern should contain path, count, percentage, and depth information.
             total_records (int): Total number of records in the original dataset
                 for statistical context and percentage validation.
-            top (int): Maximum number of top elements to include per tree level
+            limit (int): Maximum number of top elements to include per tree level
                 for focused analysis and performance optimization.
 
         Example:
@@ -439,29 +439,29 @@ class TreeBuilder:
             ...     Pattern(path="successful_login", count=350, percentage=70.0, depth=1, samples=[]),
             ... ]
             >>>
-            >>> # Build tree for security dashboard (top 10 per level)
-            >>> security_builder = TreeBuilder(security_patterns, total_records=500, top=10)
+            >>> # Build tree for security dashboard (limit 10 per level)
+            >>> security_builder = TreeBuilder(security_patterns, total_records=500, limit=10)
             >>>
             >>> print(f"Security Tree Builder Initialized:")
             >>> print(f"- Source patterns: {len(security_builder.patterns)}")
             >>> print(f"- Total records context: {security_builder.total_records}")
-            >>> print(f"- Focus level: Top {security_builder.top} per level")
+            >>> print(f"- Focus level: top {security_builder.limit} per level")
             >>>
             >>> # Example output:
             >>> # Security Tree Builder Initialized:
             >>> # - Source patterns: 3
             >>> # - Total records context: 500
-            >>> # - Focus level: Top 10 per level
+            >>> # - Focus level: top 10 per level
 
         Notes:
             - Configuration parameters are validated during initialization
             - Pattern data is preserved in original form for tree construction
-            - Top-N parameter enables performance optimization for large datasets
+            - top-N parameter enables performance optimization for large datasets
 
         """
         self.patterns = patterns
         self.total_records = total_records
-        self.top = top
+        self.limit = limit
 
     def build(self) -> Dict[str, Any]:
         r"""Build comprehensive, JSON-ready tree structure from pattern data.
@@ -474,7 +474,7 @@ class TreeBuilder:
         The building process includes:
         1. Pattern grouping by hierarchical relationships
         2. Statistical measure preservation and validation
-        3. Top-N filtering for performance optimization
+        3. top-N filtering for performance optimization
         4. JSON format optimization for visualization frameworks
         5. Metadata inclusion for business intelligence context
         6. Performance optimization for real-time applications
@@ -486,7 +486,7 @@ class TreeBuilder:
                 - value: Total record count for statistical context
                 - percentage: Root percentage (always 100.0)
                 - node: Tree level indicator (0 for root)
-                - top: Configuration parameter for reference
+                - limit: Configuration parameter for reference
 
         Example:
             Building customer segmentation tree for business intelligence:
@@ -500,7 +500,7 @@ class TreeBuilder:
             ...     Pattern(path="smb > north_america", count=180, percentage=36.0, depth=2, samples=[]),
             ... ]
             >>>
-            >>> builder = TreeBuilder(segmentation_patterns, total_records=500, top=3)
+            >>> builder = TreeBuilder(segmentation_patterns, total_records=500, limit=3)
             >>> customer_tree = builder.build()
             >>>
             >>> print(f"Customer Segmentation Tree Analysis:")
@@ -553,7 +553,7 @@ class TreeBuilder:
             ...     Pattern(path="phishing > email", count=150, percentage=30.0, depth=2, samples=[]),
             ... ]
             >>>
-            >>> security_builder = TreeBuilder(threat_patterns, total_records=500, top=5)
+            >>> security_builder = TreeBuilder(threat_patterns, total_records=500, limit=5)
             >>> threat_tree = security_builder.build()
             >>>
             >>> print(f"Security Threat Landscape Analysis:")
@@ -605,7 +605,7 @@ class TreeBuilder:
             "value": self.total_records,
             "percentage": 100.0,
             "node": 0,
-            "top": self.top,
+            "limit": self.limit,
         }
 
     def _build_empty_tree(self) -> Dict[str, Any]:
@@ -625,7 +625,7 @@ class TreeBuilder:
             Handling empty pattern scenarios:
 
             >>> # Empty pattern scenario
-            >>> empty_builder = TreeBuilder([], total_records=100, top=5)
+            >>> empty_builder = TreeBuilder([], total_records=100, limit=5)
             >>> empty_tree = empty_builder._build_empty_tree()
             >>>
             >>> print(f"Empty Tree Structure:")
@@ -653,7 +653,7 @@ class TreeBuilder:
             "value": self.total_records,
             "percentage": 100.0,
             "node": 0,
-            "top": self.top,
+            "limit": self.limit,
         }
 
     def _group_patterns_by_hierarchy(self) -> Dict[str, Any]:
@@ -761,10 +761,10 @@ class TreeBuilder:
         """
         children = []
 
-        # Sort by count and take top N
+        # Sort by count and take limit N
         sorted_items = sorted(
             data.items(), key=lambda x: x[1].get("count", 0), reverse=True
-        )[: self.top]
+        )[: self.limit]
 
         for name, node_data in sorted_items:
             node = {

--- a/dataspot/analyzers/pattern_extractor.py
+++ b/dataspot/analyzers/pattern_extractor.py
@@ -352,7 +352,7 @@ class TreeBuilder:
     This class specializes in:
     - Clean tree structure generation for visualization frameworks
     - Hierarchical data organization and optimization
-    - top-N filtering for focused analysis
+    - Top-N filtering for focused analysis
     - JSON-ready format generation with metadata
     - Performance optimization for large pattern sets
     - Statistical measure preservation during transformation
@@ -409,7 +409,7 @@ class TreeBuilder:
 
     Notes:
         - Tree structures are optimized for JSON serialization and visualization
-        - top-N filtering ensures focused analysis on most significant patterns
+        - Top-N filtering ensures focused analysis on most significant patterns
         - Hierarchical organization maintains business relationship context
         - Performance is optimized for real-time dashboard and reporting systems
 
@@ -456,7 +456,7 @@ class TreeBuilder:
         Notes:
             - Configuration parameters are validated during initialization
             - Pattern data is preserved in original form for tree construction
-            - top-N parameter enables performance optimization for large datasets
+            - Top-N parameter enables performance optimization for large datasets
 
         """
         self.patterns = patterns
@@ -474,7 +474,7 @@ class TreeBuilder:
         The building process includes:
         1. Pattern grouping by hierarchical relationships
         2. Statistical measure preservation and validation
-        3. top-N filtering for performance optimization
+        3. Top-N filtering for performance optimization
         4. JSON format optimization for visualization frameworks
         5. Metadata inclusion for business intelligence context
         6. Performance optimization for real-time applications
@@ -724,7 +724,7 @@ class TreeBuilder:
 
         Transforms internal tree data structure into JSON format optimized
         for visualization frameworks and business intelligence dashboards.
-        Applies top-N filtering and statistical measure preservation during
+        Applies Top-N filtering and statistical measure preservation during
         the conversion process.
 
         Args:
@@ -752,7 +752,7 @@ class TreeBuilder:
             >>> # ]
 
         Notes:
-            - Applies top-N filtering for performance optimization
+            - Applies Top-N filtering for performance optimization
             - Preserves all statistical measures for business analysis
             - Sorts by count for most significant patterns first
             - Maintains hierarchical structure for visualization frameworks

--- a/dataspot/analyzers/tree.py
+++ b/dataspot/analyzers/tree.py
@@ -424,7 +424,7 @@ class Tree(Base):
                 value=0,
                 percentage=0.0,
                 node=0,
-                top=options.top,
+                limit=options.limit,
                 statistics=empty_statistics,
                 fields_analyzed=input.fields,
             )
@@ -441,7 +441,9 @@ class Tree(Base):
         filtered_patterns = PatternFilter(all_patterns).apply_all(**filter_kwargs)
 
         # Build and return clean JSON tree
-        tree_result = TreeBuilder(filtered_patterns, total_records, options.top).build()
+        tree_result = TreeBuilder(
+            filtered_patterns, total_records, options.limit
+        ).build()
 
         # Convert tree result to TreeOutput
         children = self._convert_tree_children(tree_result.get("children", []))
@@ -459,7 +461,7 @@ class Tree(Base):
             value=tree_result.get("value", 0),
             percentage=tree_result.get("percentage", 0.0),
             node=tree_result.get("node", 0),
-            top=options.top,
+            limit=options.limit,
             statistics=statistics,
             fields_analyzed=input.fields,
         )
@@ -552,7 +554,7 @@ class Tree(Base):
 
         return tree_nodes
 
-    def _build_empty_tree(self, top: int) -> Dict[str, Any]:
+    def _build_empty_tree(self, limit: int) -> Dict[str, Any]:
         """Build clean empty tree structure for edge cases and error handling.
 
         Creates a properly structured empty tree when no data is available
@@ -561,7 +563,7 @@ class Tree(Base):
         or completely filtered out.
 
         Args:
-            top (int): Maximum number of top elements per tree level,
+            limit (int): Maximum number of top elements per tree level,
                 preserved in empty tree structure for configuration consistency.
 
         Returns:
@@ -575,7 +577,7 @@ class Tree(Base):
             Handling empty dataset scenarios gracefully:
 
             >>> # Empty tree construction
-            >>> empty_tree = tree._build_empty_tree(top=5)
+            >>> empty_tree = tree._build_empty_tree(limit=5)
             >>>
             >>> print(f"Empty Tree Structure:")
             >>> print(f"- Root name: {empty_tree['name']}")
@@ -583,7 +585,7 @@ class Tree(Base):
             >>> print(f"- Root value: {empty_tree['value']}")
             >>> print(f"- Coverage percentage: {empty_tree['percentage']}")
             >>> print(f"- Tree level: {empty_tree['node']}")
-            >>> print(f"- Configuration preserved: top={empty_tree['top']}")
+            >>> print(f"- Configuration preserved: limit={empty_tree['limit']}")
             >>>
             >>> # Example output:
             >>> # Empty Tree Structure:
@@ -592,7 +594,7 @@ class Tree(Base):
             >>> # - Root value: 0
             >>> # - Coverage percentage: 0.0
             >>> # - Tree level: 0
-            >>> # - Configuration preserved: top=5
+            >>> # - Configuration preserved: limit=5
 
         Notes:
             - Maintains consistent structure for visualization framework integration
@@ -607,5 +609,5 @@ class Tree(Base):
             "value": 0,
             "percentage": 0.0,
             "node": 0,
-            "top": top,
+            "limit": limit,
         }

--- a/dataspot/models/tree.py
+++ b/dataspot/models/tree.py
@@ -22,7 +22,7 @@ class TreeOptions:
     """Options for hierarchical tree visualization.
 
     Args:
-        top: Top elements per tree level (1-20).
+        limit: Maximum elements per tree level (1-100).
             Limits branches per node. Common: 5 (balanced), 3 (simple), 10 (detailed).
         min_count: Minimum record count per node.
             Excludes small nodes. Common: 1 (show all), 5 (significant only), 10 (major only).
@@ -45,7 +45,7 @@ class TreeOptions:
 
     """
 
-    top: int = 5
+    limit: int = 5
     min_count: Optional[int] = None
     min_percentage: Optional[float] = None
     max_count: Optional[int] = None
@@ -120,7 +120,7 @@ class TreeOutput:
     value: int  # Total number of records
     percentage: float  # Percentage of total records (typically 100.0)
     node: int  # Root node identifier (typically 0)
-    top: int  # Number of top elements considered per level
+    limit: int  # Number of top elements considered per level
     statistics: TreeStatistics  # Analysis statistics
     fields_analyzed: List[str]  # Fields that were analyzed
 

--- a/examples/06_real_world_scenarios.py
+++ b/examples/06_real_world_scenarios.py
@@ -266,7 +266,7 @@ def main():
     # Build hierarchical tree for dashboard
     tree = dataspot.tree(
         TreeInput(data=dashboard_data, fields=["region", "device", "user"]),
-        TreeOptions(min_percentage=10.0, top=3),
+        TreeOptions(min_percentage=10.0, limit=3),
     )
 
     print("Dashboard tree structure:")

--- a/examples/07_tree_visualization.py
+++ b/examples/07_tree_visualization.py
@@ -1,107 +1,106 @@
-"""Tree Visualization Examples.
+#!/usr/bin/env python3
+"""Tree Visualization.
 
-Shows how to use the tree() method to build hierarchical JSON structures for dashboards and visualization.
+This example demonstrates how to use the Tree analyzer to create
+hierarchical data structures for visualization purposes.
 """
 
-import json
-
-from dataspot import Dataspot
+from dataspot.analyzers.tree import Tree
 from dataspot.models.tree import TreeInput, TreeOptions
 
-# Simple e-commerce data
+# Sample e-commerce data
 data = [
-    {
-        "country": "US",
-        "device": "mobile",
-        "user_type": "premium",
-        "category": "electronics",
-    },
-    {"country": "US", "device": "mobile", "user_type": "free", "category": "books"},
-    {
-        "country": "US",
-        "device": "desktop",
-        "user_type": "premium",
-        "category": "electronics",
-    },
-    {
-        "country": "EU",
-        "device": "mobile",
-        "user_type": "premium",
-        "category": "clothing",
-    },
-    {
-        "country": "EU",
-        "device": "tablet",
-        "user_type": "free",
-        "category": "electronics",
-    },
-    {"country": "CA", "device": "mobile", "user_type": "premium", "category": "books"},
-] * 2  # 12 records total
+    {"country": "US", "device": "mobile", "category": "electronics"},
+    {"country": "US", "device": "mobile", "category": "electronics"},
+    {"country": "US", "device": "mobile", "category": "clothing"},
+    {"country": "US", "device": "desktop", "category": "electronics"},
+    {"country": "US", "device": "desktop", "category": "electronics"},
+    {"country": "UK", "device": "mobile", "category": "electronics"},
+    {"country": "UK", "device": "mobile", "category": "books"},
+    {"country": "UK", "device": "desktop", "category": "books"},
+    {"country": "DE", "device": "mobile", "category": "electronics"},
+    {"country": "DE", "device": "tablet", "category": "clothing"},
+]
 
+print("🌳 Tree Visualization Examples\n")
 
-def main():
-    """Tree visualization examples."""
-    dataspot = Dataspot()
+# Basic tree visualization
+print("1. Basic Tree Structure:")
+tree_basic = Tree().execute(
+    TreeInput(data=data, fields=["country", "device"]), TreeOptions(limit=3)
+)
 
-    print("=== 1. Basic Tree Structure ===")
+print(f"Root: {tree_basic.name}")
+print(f"Top level children: {len(tree_basic.children)}")
+for child in tree_basic.children:
+    print(f"  - {child.name}: {child.value} records ({child.percentage:.1f}%)")
 
-    # Simple 2-level tree
-    tree_basic = dataspot.tree(
-        TreeInput(data=data, fields=["country", "device"]), TreeOptions(top=3)
-    )
-    print(f"Root value: {tree_basic.value} records")
-    print(f"Top level children: {len(tree_basic.children)}")
+print("\n" + "=" * 50 + "\n")
 
-    # Show tree as JSON
-    print("\nTree structure:")
-    tree_dict = tree_basic.to_dict()
-    print(json.dumps(tree_dict, indent=2))
+# Tree with filters
+print("2. Tree with Count Filter:")
+tree_filtered = Tree().execute(
+    TreeInput(data=data, fields=["country", "device", "category"]),
+    TreeOptions(min_count=2, limit=3),
+)
 
-    print("\n=== 2. Filtered Tree ===")
+print(f"Filtered patterns: {tree_filtered.statistics.patterns_found}")
+print("Country breakdown:")
+for child in tree_filtered.children:
+    print(f"  - {child.name}: {child.value} records")
 
-    # Tree with filtering
-    tree_filtered = dataspot.tree(
-        TreeInput(data=data, fields=["country", "device", "user_type"]),
-        TreeOptions(min_count=2, top=3),
-    )
-    print(f"Filtered tree children: {len(tree_filtered.children)}")
+print("\n" + "=" * 50 + "\n")
 
-    print("\n=== 3. Query + Tree ===")
+# Tree with percentage filter
+print("3. Tree with Percentage Filter:")
+tree_percentage = Tree().execute(
+    TreeInput(data=data, fields=["country", "device"]),
+    TreeOptions(limit=3),
+)
 
-    # Tree with query filter
-    tree_query = dataspot.tree(
-        TreeInput(data=data, fields=["device", "user_type"], query={"country": "US"}),
-        TreeOptions(top=3),
-    )
-    print(f"US-only tree value: {tree_query.value} records")
-    print(f"US tree children: {len(tree_query.children)}")
+print("High-concentration patterns:")
+for child in tree_percentage.children:
+    if child.percentage > 20:
+        print(f"  - {child.name}: {child.percentage:.1f}%")
 
-    print("\n=== 4. Dashboard Structure ===")
+print("\n" + "=" * 50 + "\n")
 
-    # Optimized for dashboard
-    tree_dashboard = dataspot.tree(
-        TreeInput(data=data, fields=["country", "device", "user_type"]),
-        TreeOptions(min_percentage=15.0, top=2),
-    )
+# Tree with minimum percentage threshold
+print("4. Tree with Minimum Percentage Threshold:")
+tree_insights = Tree().execute(
+    TreeInput(data=data, fields=["country", "device", "category"]),
+    TreeOptions(min_percentage=15.0, limit=2),
+)
 
-    print("Dashboard-ready tree:")
-    dashboard_dict = tree_dashboard.to_dict()
-    print(json.dumps(dashboard_dict, indent=2))
+print(f"Total records analyzed: {tree_insights.statistics.total_records}")
+print(f"Patterns found: {tree_insights.statistics.patterns_found}")
 
-    print("\n=== 5. Tree Insights ===")
+if tree_insights.children:
+    top_pattern = tree_insights.children[0]
+    print(f"🌍 Top pattern: {top_pattern.name} ({top_pattern.percentage:.1f}%)")
 
-    # Extract key insights
-    tree_insights = dataspot.tree(
-        TreeInput(data=data, fields=["country", "device"]), TreeOptions()
-    )
+print("\n" + "=" * 50 + "\n")
 
-    print(f"📊 Total records: {tree_insights.value}")
-    print(f"🔝 Main patterns: {len(tree_insights.children)}")
+# Export tree as JSON for D3.js or other visualization libraries
+print("5. JSON Export for Visualization Libraries:")
+tree_json = Tree().execute(
+    TreeInput(data=data, fields=["country", "device"]), TreeOptions(limit=3)
+)
 
-    if tree_insights.children:
-        top_pattern = tree_insights.children[0]
-        print(f"🌍 Top pattern: {top_pattern.name} ({top_pattern.percentage:.1f}%)")
+# Convert to dict for JSON export
+tree_dict = tree_json.to_dict()
+print("JSON structure keys:", list(tree_dict.keys()))
+print(f"Ready for D3.js: {len(tree_dict['children'])} top-level nodes")
 
+# Example of how this could be used with D3.js
+print("\n📊 Visualization Integration:")
+print("This tree structure can be directly used with:")
+print("- D3.js hierarchical layouts")
+print("- Chart.js tree charts")
+print("- React tree components")
+print("- Custom visualization frameworks")
 
-if __name__ == "__main__":
-    main()
+print("\nTree statistics:")
+print(f"- Total records: {tree_json.statistics.total_records}")
+print(f"- Patterns discovered: {tree_json.statistics.patterns_found}")
+print(f"- Analysis depth: {len(tree_json.fields_analyzed)} levels")

--- a/examples/07_tree_visualization.py
+++ b/examples/07_tree_visualization.py
@@ -90,7 +90,7 @@ tree_json = Tree().execute(
 # Convert to dict for JSON export
 tree_dict = tree_json.to_dict()
 print("JSON structure keys:", list(tree_dict.keys()))
-print(f"Ready for D3.js: {len(tree_dict['children'])} top-level nodes")
+print(f"Ready for D3.js: {len(tree_dict['children'])} Top-level nodes")
 
 # Example of how this could be used with D3.js
 print("\n📊 Visualization Integration:")

--- a/tests/analyzers/test_tree.py
+++ b/tests/analyzers/test_tree.py
@@ -37,7 +37,7 @@ class TestTreeCore:
         assert result.value == 0
         assert result.percentage == 0.0
         assert result.node == 0
-        assert result.top == 5  # Default top value
+        assert result.limit == 5  # Default limit value
 
     def test_execute_with_empty_fields(self):
         """Test execute method with empty fields list."""
@@ -76,26 +76,26 @@ class TestTreeCore:
         assert result.value == 3
         assert result.percentage == 100.0
         assert result.node == 0
-        assert result.top == 5
+        assert result.limit == 5
 
         # Check children exist
         assert result.children is not None
         assert len(result.children) > 0
         assert all(hasattr(child, "name") for child in result.children)
 
-    def test_execute_with_custom_top(self):
-        """Test execute method with custom top parameter."""
+    def test_execute_with_custom_limit(self):
+        """Test execute method with custom limit parameter."""
         data = [
             {"country": "US", "device": "mobile"},
             {"country": "EU", "device": "desktop"},
         ]
 
         tree_input = TreeInput(data=data, fields=["country", "device"])
-        tree_options = TreeOptions(top=3)
+        tree_options = TreeOptions(limit=3)
+
         result = self.tree.execute(tree_input, tree_options)
 
-        assert isinstance(result, TreeOutput)
-        assert result.top == 3
+        assert result.limit == 3
 
     def test_execute_with_query_filter(self):
         """Test execute method with query filtering."""
@@ -118,8 +118,25 @@ class TestTreeCore:
         assert result.percentage == 100.0
 
     def test_build_empty_tree(self):
-        """Test _build_empty_tree method."""
-        result = self.tree._build_empty_tree(top=10)
+        """Test building empty tree structure."""
+        data = [
+            {"country": "US", "device": "desktop", "active": False},
+        ]
+
+        tree_input = TreeInput(
+            data=data, fields=["country", "device"], query={"active": True}
+        )
+
+        result = self.tree.execute(tree_input)
+
+        assert result.name == "root"
+        assert len(result.children) == 0
+        assert result.value == 0
+        assert result.percentage == 0.0
+
+    def test_build_empty_tree_method(self):
+        """Test the _build_empty_tree method directly."""
+        result = self.tree._build_empty_tree(limit=10)
 
         expected = {
             "name": "root",
@@ -127,7 +144,7 @@ class TestTreeCore:
             "value": 0,
             "percentage": 0.0,
             "node": 0,
-            "top": 10,
+            "limit": 10,
         }
 
         assert result == expected
@@ -451,12 +468,12 @@ class TestTreeEdgeCases:
         ]
 
         tree_input = TreeInput(data=data, fields=["category", "value"])
-        tree_options = TreeOptions(top=3)
+        tree_options = TreeOptions(limit=3)
         result = self.tree.execute(tree_input, tree_options)
 
         assert isinstance(result, TreeOutput)
         assert result.value == 500
-        assert result.top == 3
+        assert result.limit == 3
 
         # Should complete reasonably quickly and not cause memory issues
 

--- a/tests/unit/test_dataspot_api.py
+++ b/tests/unit/test_dataspot_api.py
@@ -227,7 +227,7 @@ class TestDataspotTree:
         tree_input = TreeInput(
             data=self.test_data, fields=["type"], query={"category": "A"}
         )
-        tree_options = TreeOptions(top=3, min_count=1, max_depth=2)
+        tree_options = TreeOptions(limit=3, min_count=1, max_depth=2)
         result = self.dataspot.tree(tree_input, tree_options)
 
         assert isinstance(result, TreeOutput)


### PR DESCRIPTION
- Updated parameter names in TreeOptions, TreeBuilder, and related classes to replace 'top' with 'limit' for clarity.
- Adjusted logic in Compare, Discovery, and Tree analyzers to respect the new limit parameter.
- Enhanced documentation and examples to reflect the changes in parameter naming.
- Updated unit tests to ensure functionality aligns with the new parameter structure.